### PR TITLE
feat: Add overall CI status check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,14 @@ jobs:
         with:
           name: dist
           path: dist/
+
+  status-check:
+    runs-on: ubuntu-latest
+    needs: [lint, test, build]
+    if: always()
+    steps:
+      - name: Check workflow status
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+      - name: All jobs passed
+        run: echo "All jobs passed"


### PR DESCRIPTION
Introduces a new 'status-check' job to the CI workflow. This job depends on 'lint', 'test', and 'build' jobs and will fail if any of them fail or are cancelled. This provides a single consolidated status for the entire CI run, useful for branch protection rules.