### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/unlibra/tkinter-unblur/security/code-scanning/4](https://github.com/unlibra/tkinter-unblur/security/code-scanning/4)

To fix the problem, add a `permissions` block at the root level of the workflow file, `.github/workflows/ci.yml`. This sets the default permissions for all jobs to the least privilege necessary. From inspection, the jobs in the workflow do not push code or create releases; their main activities are checking out code, setting up Python, installing dependencies, running lint/test/build commands, and uploading artifacts. All these tasks only need read access to repository contents. Therefore, set `permissions: contents: read` at the top-level, above `jobs:`, so all jobs inherit this restriction unless they have their own explicit permissions block. No changes to imports, variables, or definitions are needed; just insert the required YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
